### PR TITLE
Digitally sign assemblies when built in TeamCity

### DIFF
--- a/RedGate.AppHost.Client/RedGate.AppHost.Client.csproj
+++ b/RedGate.AppHost.Client/RedGate.AppHost.Client.csproj
@@ -59,6 +59,7 @@
   </PropertyGroup>
   <!-- Don't try to sign if it's built inside visual studio, there's probably no point -->
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == ''">
+    <RedGate_DontObfuscate>true</RedGate_DontObfuscate> <!-- Need to set this to tell signing task where to look for assembly -->
     <RedGate_DoSign>true</RedGate_DoSign>
   </PropertyGroup>
   <ItemGroup>

--- a/RedGate.AppHost.Client/RedGate.AppHost.Client.x64.csproj
+++ b/RedGate.AppHost.Client/RedGate.AppHost.Client.x64.csproj
@@ -59,6 +59,7 @@
   </PropertyGroup>
   <!-- Don't try to sign if it's built inside visual studio, there's probably no point -->
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == ''">
+    <RedGate_DontObfuscate>true</RedGate_DontObfuscate> <!-- Need to set this to tell signing task where to look for assembly -->
     <RedGate_DoSign>true</RedGate_DoSign>
   </PropertyGroup>
   <ItemGroup>

--- a/RedGate.AppHost.Interfaces/RedGate.AppHost.Interfaces.csproj
+++ b/RedGate.AppHost.Interfaces/RedGate.AppHost.Interfaces.csproj
@@ -36,6 +36,7 @@
   </PropertyGroup>
   <!-- Don't try to sign if it's built inside visual studio, there's probably no point -->
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == ''">
+    <RedGate_DontObfuscate>true</RedGate_DontObfuscate> <!-- Need to set this to tell signing task where to look for assembly -->
     <RedGate_DoSign>true</RedGate_DoSign>
   </PropertyGroup>
   <ItemGroup>

--- a/RedGate.AppHost.Remoting.WPF/RedGate.AppHost.Remoting.WPF.csproj
+++ b/RedGate.AppHost.Remoting.WPF/RedGate.AppHost.Remoting.WPF.csproj
@@ -35,6 +35,7 @@
   </PropertyGroup>
   <!-- Don't try to sign if it's built inside visual studio, there's probably no point -->
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == ''">
+    <RedGate_DontObfuscate>true</RedGate_DontObfuscate> <!-- Need to set this to tell signing task where to look for assembly -->
     <RedGate_DoSign>true</RedGate_DoSign>
   </PropertyGroup>
   <ItemGroup>

--- a/RedGate.AppHost.Remoting/RedGate.AppHost.Remoting.csproj
+++ b/RedGate.AppHost.Remoting/RedGate.AppHost.Remoting.csproj
@@ -36,6 +36,7 @@
   </PropertyGroup>
   <!-- Don't try to sign if it's built inside visual studio, there's probably no point -->
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == ''">
+    <RedGate_DontObfuscate>true</RedGate_DontObfuscate> <!-- Need to set this to tell signing task where to look for assembly -->
     <RedGate_DoSign>true</RedGate_DoSign>
   </PropertyGroup>
   <ItemGroup>

--- a/RedGate.AppHost.Server/RedGate.AppHost.Server.csproj
+++ b/RedGate.AppHost.Server/RedGate.AppHost.Server.csproj
@@ -36,6 +36,7 @@
   </PropertyGroup>
   <!-- Don't try to sign if it's built inside visual studio, there's probably no point -->
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == ''">
+    <RedGate_DontObfuscate>true</RedGate_DontObfuscate> <!-- Need to set this to tell signing task where to look for assembly -->
     <RedGate_DoSign>true</RedGate_DoSign>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Add the build magic for assembly signing (ref: http://wiki/How_to_Set_Up_Visual_Studio_Projects_and_Solutions#Digital_Signatures) to assemblies which might be redistributed.
