### PR TITLE
Fix .NET version

### DIFF
--- a/Install/RedGate.AppHost.wxs
+++ b/Install/RedGate.AppHost.wxs
@@ -5,6 +5,7 @@
 		<DirectoryRef Id="INSTALLDIR">
 			<Component Id="AppHostCore" Guid="{0A6DBAE8-0CFD-41D9-B27A-6AD72181CB7D}">
 				<File Id="Client" Name="AHClient.exe" LongName="RedGate.AppHost.Client.exe" DiskId="1" src="RedGate.AppHost.Client.exe" /> 
+				<File Id="ClientConfig" Name="AHClient.cfg" LongName="RedGate.AppHost.Client.exe.config" DiskId="1" src="RedGate.AppHost.Client.exe.config" />
 				<File Id="Server" Name="AHServer.dll" LongName="RedGate.AppHost.Server.dll" DiskId="1" src="RedGate.AppHost.Server.dll" /> 
 				<File Id="Interfaces" Name="AHIfaces.dll" LongName="RedGate.AppHost.Interfaces.dll" DiskId="1" src="RedGate.AppHost.Interfaces.dll" /> 
 				<File Id="Remoting" Name="AHRemote.dll" LongName="RedGate.AppHost.Remoting.dll" DiskId="1" src="RedGate.AppHost.Remoting.dll" /> 

--- a/Install/RedGate.AppHost.wxs
+++ b/Install/RedGate.AppHost.wxs
@@ -7,6 +7,7 @@
 				<File Id="Client" Name="AHClient.exe" LongName="RedGate.AppHost.Client.exe" DiskId="1" src="RedGate.AppHost.Client.exe" /> 
 				<File Id="ClientConfig" Name="AHClient.cfg" LongName="RedGate.AppHost.Client.exe.config" DiskId="1" src="RedGate.AppHost.Client.exe.config" />
 				<File Id="Client64" Name="AHClt64.exe" LongName="RedGate.AppHost.Client.x64.exe" DiskId="1" src="RedGate.AppHost.Client.x64.exe" /> 
+				<File Id="Client64Config" Name="AHClt64.cfg" LongName="RedGate.AppHost.Client.x64.exe.config" DiskId="1" src="RedGate.AppHost.Client.x64.exe.config" />
 				<File Id="Server" Name="AHServer.dll" LongName="RedGate.AppHost.Server.dll" DiskId="1" src="RedGate.AppHost.Server.dll" /> 
 				<File Id="Interfaces" Name="AHIfaces.dll" LongName="RedGate.AppHost.Interfaces.dll" DiskId="1" src="RedGate.AppHost.Interfaces.dll" /> 
 				<File Id="Remoting" Name="AHRemote.dll" LongName="RedGate.AppHost.Remoting.dll" DiskId="1" src="RedGate.AppHost.Remoting.dll" /> 

--- a/NuSpec/RedGate.AppHost.nuspec
+++ b/NuSpec/RedGate.AppHost.nuspec
@@ -26,8 +26,10 @@
     <file src="RedGate.AppHost.Example.Server.exe" target="lib" />
     <file src="RedGate.AppHost.Example.Remote.Services.dll" target="lib" />
     <file src="RedGate.AppHost.Client.exe" target="lib" />
+    <file src="RedGate.AppHost.Client.exe.config" target="lib" />
     <file src="RedGate.AppHost.Client.pdb" target="lib" />
     <file src="RedGate.AppHost.Client.x64.exe" target="lib" />
+    <file src="RedGate.AppHost.Client.x64.exe.config" target="lib" />
     <file src="RedGate.AppHost.Client.x64.pdb" target="lib" />
     <file src="RedGate.AppHost.Interfaces.dll" target="lib" />
     <file src="RedGate.AppHost.Interfaces.pdb" target="lib" />

--- a/RedGate.AppHost.Client/RedGate.AppHost.Client.csproj
+++ b/RedGate.AppHost.Client/RedGate.AppHost.Client.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RedGate.AppHost.Client</RootNamespace>
     <AssemblyName>RedGate.AppHost.Client</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>\\red-gate.com\Files\RG_Build_Key\RedGate.snk</AssemblyOriginatorKeyFile>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />
@@ -59,12 +60,14 @@
   </PropertyGroup>
   <!-- Don't try to sign if it's built inside visual studio, there's probably no point -->
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == ''">
-    <RedGate_DontObfuscate>true</RedGate_DontObfuscate> <!-- Need to set this to tell signing task where to look for assembly -->
+    <RedGate_DontObfuscate>true</RedGate_DontObfuscate>
+    <!-- Need to set this to tell signing task where to look for assembly -->
     <RedGate_DoSign>true</RedGate_DoSign>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine">
-      <HintPath>..\packages\CommandLineParser.1.9.71\lib\net40\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\CommandLineParser.1.9.71\lib\net35\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -72,10 +75,8 @@
     <Reference Include="System.AddIn.Contract" />
     <Reference Include="System.Core" />
     <Reference Include="System.Windows.Presentation" />
-    <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
@@ -102,6 +103,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/RedGate.AppHost.Client/RedGate.AppHost.Client.x64.csproj
+++ b/RedGate.AppHost.Client/RedGate.AppHost.Client.x64.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RedGate.AppHost.Client</RootNamespace>
     <AssemblyName>RedGate.AppHost.Client.x64</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>\\red-gate.com\Files\RG_Build_Key\RedGate.snk</AssemblyOriginatorKeyFile>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />
@@ -59,12 +60,14 @@
   </PropertyGroup>
   <!-- Don't try to sign if it's built inside visual studio, there's probably no point -->
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == ''">
-    <RedGate_DontObfuscate>true</RedGate_DontObfuscate> <!-- Need to set this to tell signing task where to look for assembly -->
+    <RedGate_DontObfuscate>true</RedGate_DontObfuscate>
+    <!-- Need to set this to tell signing task where to look for assembly -->
     <RedGate_DoSign>true</RedGate_DoSign>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine">
-      <HintPath>..\packages\CommandLineParser.1.9.71\lib\net40\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\CommandLineParser.1.9.71\lib\net35\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -72,10 +75,8 @@
     <Reference Include="System.AddIn.Contract" />
     <Reference Include="System.Core" />
     <Reference Include="System.Windows.Presentation" />
-    <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
@@ -102,6 +103,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/RedGate.AppHost.Client/app.config
+++ b/RedGate.AppHost.Client/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup>
-        <supportedRuntime version="v2.0.50727"/>
         <supportedRuntime version="v4.0"/>
+        <supportedRuntime version="v2.0.50727"/>
     </startup>
 </configuration>

--- a/RedGate.AppHost.Client/app.config
+++ b/RedGate.AppHost.Client/app.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup>
+        <supportedRuntime version="v2.0.50727"/>
+        <supportedRuntime version="v4.0"/>
+    </startup>
+</configuration>

--- a/RedGate.AppHost.Client/packages.config
+++ b/RedGate.AppHost.Client/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommandLineParser" version="1.9.71" targetFramework="net40" />
+  <package id="CommandLineParser" version="1.9.71" targetFramework="net35" />
 </packages>

--- a/RedGate.AppHost.Example.Client/RedGate.AppHost.Example.Client.csproj
+++ b/RedGate.AppHost.Example.Client/RedGate.AppHost.Example.Client.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RedGate.AppHost.Example.Client</RootNamespace>
     <AssemblyName>RedGate.AppHost.Example.Client</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>\\red-gate.com\Files\RG_Build_Key\RedGate.snk</AssemblyOriginatorKeyFile>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -38,10 +39,8 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />

--- a/RedGate.AppHost.Example.Remote.Services/RedGate.AppHost.Example.Remote.Services.csproj
+++ b/RedGate.AppHost.Example.Remote.Services/RedGate.AppHost.Example.Remote.Services.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RedGate.AppHost.Example.Remote.Services</RootNamespace>
     <AssemblyName>RedGate.AppHost.Example.Remote.Services</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SignAssembly>true</SignAssembly>
@@ -37,7 +37,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/RedGate.AppHost.Example.Server/RedGate.AppHost.Example.Server.csproj
+++ b/RedGate.AppHost.Example.Server/RedGate.AppHost.Example.Server.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RedGate.AppHost.Example.Server</RootNamespace>
     <AssemblyName>RedGate.AppHost.Example.Server</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>\\red-gate.com\Files\RG_Build_Key\RedGate.snk</AssemblyOriginatorKeyFile>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -41,13 +42,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Windows.Presentation" />
     <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Xaml">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -90,6 +87,7 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <None Include="app.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/RedGate.AppHost.Example.Server/app.config
+++ b/RedGate.AppHost.Example.Server/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup>
-        <supportedRuntime version="v2.0.50727"/>
         <supportedRuntime version="v4.0"/>
+        <supportedRuntime version="v2.0.50727"/>
     </startup>
 </configuration>

--- a/RedGate.AppHost.Example.Server/app.config
+++ b/RedGate.AppHost.Example.Server/app.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup>
+        <supportedRuntime version="v2.0.50727"/>
+        <supportedRuntime version="v4.0"/>
+    </startup>
+</configuration>


### PR DESCRIPTION
Some of the projects targeted .NET 3.5, others .NET 4.0; it seemed accidental (but perhaps not?). This caused us problems in SoC, because in many cases we run in a .NET 2.0 process and so our installer doesn't currently mandate .NET 4.0 be present. I'm not sure now what the original intention was for .NET versions in this library, so I thought I'd make this change and see what happened :smile: 

(Note, this includes #3 too.)