### PR TITLE
Increase timeout from 20s to 2 minutes.

### DIFF
--- a/RedGate.AppHost.Server/StartProcessWithTimeout.cs
+++ b/RedGate.AppHost.Server/StartProcessWithTimeout.cs
@@ -8,7 +8,7 @@ namespace RedGate.AppHost.Server
     {
         private readonly IProcessStartOperation m_WrappedProcessStarter;
 
-        private static readonly TimeSpan s_TimeOut = TimeSpan.FromSeconds(20);
+        private static readonly TimeSpan s_TimeOut = TimeSpan.FromMinutes(2);
 
         public StartProcessWithTimeout(IProcessStartOperation wrappedProcessStarter)
         {


### PR DESCRIPTION
We are seeing timeouts in APP on some slower machines. We may want to make this configurable in the future.