### PR TITLE
Fix for assuming any legacy call is 32-bit

### DIFF
--- a/RedGate.AppHost.Server/ChildProcessFactory.cs
+++ b/RedGate.AppHost.Server/ChildProcessFactory.cs
@@ -25,7 +25,7 @@
 
         public IChildProcessHandle Create(string assemblyName, bool openDebugConsole, bool is64Bit)
         {
-            return Create(assemblyName, openDebugConsole, false, false);
+            return Create(assemblyName, openDebugConsole, is64Bit, false);
         }
 
         public IChildProcessHandle Create(string assemblyName, bool openDebugConsole)


### PR DESCRIPTION
When you wrapped the legacy API, you hard-coded the 64-bit parameter to false, despite having a function argument to specify that.

Note I can't build this project due to not having your .SNK file, but I am assuming this fix should be solid.