### PR TITLE
Fix the icon for Redgate.AppHost.Client.x64

### DIFF
--- a/RedGate.AppHost.Client/RedGate.AppHost.Client.x64.csproj
+++ b/RedGate.AppHost.Client/RedGate.AppHost.Client.x64.csproj
@@ -63,6 +63,9 @@
     <!-- Need to set this to tell signing task where to look for assembly -->
     <RedGate_DoSign>true</RedGate_DoSign>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationIcon>honeycomb.ico</ApplicationIcon>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="CommandLine">
       <HintPath>..\packages\CommandLineParser.1.9.71\lib\net40\CommandLine.dll</HintPath>
@@ -105,6 +108,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="honeycomb.ico" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(RedGate_BuildTargetsPath)" Condition="'$(BuildingInsideVisualStudio)' == ''" />


### PR DESCRIPTION
The x64 executable did not have the same icon set as the 32 bit executable, this should fix that