### PR TITLE
Red gate/close process

### DIFF
--- a/RedGate.AppHost.Server/ChildProcessHandle.cs
+++ b/RedGate.AppHost.Server/ChildProcessHandle.cs
@@ -1,4 +1,7 @@
-﻿using System.Windows;
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.Remoting;
+using System.Windows;
 using RedGate.AppHost.Interfaces;
 using RedGate.AppHost.Remoting.WPF;
 
@@ -7,15 +10,25 @@ namespace RedGate.AppHost.Server
     internal class ChildProcessHandle : IChildProcessHandle
     {
         private readonly ISafeChildProcessHandle m_SafeChildProcessHandle;
+        public Process Process { get; }
 
-        public ChildProcessHandle(ISafeChildProcessHandle safeChildProcessHandle)
+        public ChildProcessHandle(ISafeChildProcessHandle safeChildProcessHandle, Process process)
         {
             m_SafeChildProcessHandle = safeChildProcessHandle;
+            Process = process;
         }
 
         public FrameworkElement CreateElement(IAppHostServices services)
         {
-            return m_SafeChildProcessHandle.CreateElement(services).ToFrameworkElement();
+            try
+            {
+                return m_SafeChildProcessHandle.CreateElement(services).ToFrameworkElement();
+            }
+            catch (RemotingException)
+            {
+                Process?.KillAndDispose();
+                throw;
+            }
         }
     }
 }

--- a/RedGate.AppHost.Server/ChildProcessHandle.cs
+++ b/RedGate.AppHost.Server/ChildProcessHandle.cs
@@ -10,12 +10,12 @@ namespace RedGate.AppHost.Server
     internal class ChildProcessHandle : IChildProcessHandle
     {
         private readonly ISafeChildProcessHandle m_SafeChildProcessHandle;
-        public Process Process { get; }
+        private readonly Process m_Process;
 
         public ChildProcessHandle(ISafeChildProcessHandle safeChildProcessHandle, Process process)
         {
             m_SafeChildProcessHandle = safeChildProcessHandle;
-            Process = process;
+            m_Process = process;
         }
 
         public FrameworkElement CreateElement(IAppHostServices services)
@@ -26,7 +26,7 @@ namespace RedGate.AppHost.Server
             }
             catch (RemotingException)
             {
-                Process?.KillAndDispose();
+                m_Process?.KillAndDispose();
                 throw;
             }
         }

--- a/RedGate.AppHost.Server/RemotedProcessBootstrapper.cs
+++ b/RedGate.AppHost.Server/RemotedProcessBootstrapper.cs
@@ -23,7 +23,7 @@ namespace RedGate.AppHost.Server
             try
             {
                 process = m_ProcessBootstrapper.StartProcess(assemblyName, m_RemotingId, openDebugConsole, monitorHostProcess);
-                return new ChildProcessHandle(InitializeRemoting());
+                return new ChildProcessHandle(InitializeRemoting(), process);
             }
             catch
             {


### PR DESCRIPTION
After a certain amount of time, we get the following exception when we try and call `ChildProcessHandle.CreateElement`:

```text
System.Runtime.Remoting.RemotingException: Requested Service not found

Server stack trace: 
   at System.Runtime.Remoting.Channels.BinaryServerFormatterSink.ProcessMessage(IServerChannelSinkStack sinkStack, IMessage requestMsg, ITransportHeaders requestHeaders, Stream requestStream, IMessage& responseMsg, ITransportHeaders& responseHeaders, Stream& responseStream)

Exception rethrown at [0]: 
   at System.Runtime.Remoting.Proxies.RealProxy.HandleReturnMessage(IMessage reqMsg, IMessage retMsg)
   at System.Runtime.Remoting.Proxies.RealProxy.PrivateInvoke(MessageData& msgData, Int32 type)
   at RedGate.AppHost.Interfaces.ISafeChildProcessHandle.CreateElement(IAppHostServices services)
   at RedGate.AppHost.Server.ChildProcessHandle.CreateElement(IAppHostServices services) in d:\buildagentA\work\6331e82f4310d39\RedGate.AppHost.Server\ChildProcessHandle.cs:line 18
```

This leaves the `AppHost` process in a state where we can't use it for `CreateElement`, or close it.

This change kills the process when this happens, allowing the receiving application to create a new apphost process without having the old one lying around.

We did consider keeping track of all of the services and trying to recreate them when they can't be accessed, but that could open up a lot more questions.

Let me know if there's a better way of doing it!