### PR TITLE
Fix key path

### DIFF
--- a/Install/RedGate.AppHost.wxs
+++ b/Install/RedGate.AppHost.wxs
@@ -1,26 +1,29 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2003/01/wi">
 
-	<!-- Building block fragments because apparently everything has to be contained in a fragment -->
-	<Fragment Id="AppHostCore">
-		<DirectoryRef Id="INSTALLDIR">
-			<Component Id="AppHostCore" Guid="{0A6DBAE8-0CFD-41D9-B27A-6AD72181CB7D}">
-				<File Id="Client" Name="AHClient.exe" LongName="RedGate.AppHost.Client.exe" DiskId="1" src="RedGate.AppHost.Client.exe" /> 
-				<File Id="Client64" Name="AHClt64.exe" LongName="RedGate.AppHost.Client.x64.exe" DiskId="1" src="RedGate.AppHost.Client.x64.exe" /> 
-				<File Id="Server" Name="AHServer.dll" LongName="RedGate.AppHost.Server.dll" DiskId="1" src="RedGate.AppHost.Server.dll" /> 
-				<File Id="Interfaces" Name="AHIfaces.dll" LongName="RedGate.AppHost.Interfaces.dll" DiskId="1" src="RedGate.AppHost.Interfaces.dll" /> 
-				<File Id="Remoting" Name="AHRemote.dll" LongName="RedGate.AppHost.Remoting.dll" DiskId="1" src="RedGate.AppHost.Remoting.dll" /> 
-				<File Id="WpfRemoting" Name="AHWpfRem.dll" LongName="RedGate.AppHost.Remoting.WPF.dll" DiskId="1" src="RedGate.AppHost.Remoting.WPF.dll" /> 
-				<File Id="CommandLine" Name="CLIParse.dll" LongName="CommandLine.dll" DiskId="1" src="CommandLine.dll" /> 
-			</Component>
-		</DirectoryRef>
-	</Fragment>
+  <!-- Building block fragments because apparently everything has to be contained in a fragment -->
+  <Fragment Id="AppHostCore">
+    <DirectoryRef Id="INSTALLDIR">
+      <Component Id="AppHostCore" Guid="{0A6DBAE8-0CFD-41D9-B27A-6AD72181CB7D}">
+        <File Id="Client" Name="AHClient.exe" LongName="RedGate.AppHost.Client.exe" DiskId="1" src="RedGate.AppHost.Client.exe" KeyPath="yes"/>
+        <File Id="Client64" Name="AHClt64.exe" LongName="RedGate.AppHost.Client.x64.exe" DiskId="1" src="RedGate.AppHost.Client.x64.exe" />
+        <File Id="Server" Name="AHServer.dll" LongName="RedGate.AppHost.Server.dll" DiskId="1" src="RedGate.AppHost.Server.dll" />
+        <File Id="Interfaces" Name="AHIfaces.dll" LongName="RedGate.AppHost.Interfaces.dll" DiskId="1" src="RedGate.AppHost.Interfaces.dll" />
+        <File Id="Remoting" Name="AHRemote.dll" LongName="RedGate.AppHost.Remoting.dll" DiskId="1" src="RedGate.AppHost.Remoting.dll" />
+        <File Id="WpfRemoting" Name="AHWpfRem.dll" LongName="RedGate.AppHost.Remoting.WPF.dll" DiskId="1" src="RedGate.AppHost.Remoting.WPF.dll" />
+      </Component>
+      <Component Id="APHCommandLineParser" Guid="{B03F95C6-5645-47E9-8D6B-0AC829F3E7DC}">
+        <File Id="APHCommandLine" Name="APHParse.dll" LongName="CommandLine.dll" DiskId="1" src="CommandLine.dll" KeyPath="yes"/>
+      </Component>
+    </DirectoryRef>
+  </Fragment>
 
-	<!-- Reference one of the following fragments -->
-	<Fragment Id="RedGateAppHost">
-		<FeatureRef Id="Product">
-			<ComponentRef Id="AppHostCore"/>
-		</FeatureRef>
-	</Fragment>
+  <!-- Reference one of the following fragments -->
+  <Fragment Id="RedGateAppHost">
+    <FeatureRef Id="Product">
+      <ComponentRef Id="AppHostCore"/>
+      <ComponentRef Id="APHCommandLineParser"/>
+    </FeatureRef>
+  </Fragment>
 </Wix>
 
 

--- a/RedGate.AppHost.sln
+++ b/RedGate.AppHost.sln
@@ -28,6 +28,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RedGate.AppHost.Example.Rem
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RedGate.AppHost.Client.x64", "RedGate.AppHost.Client\RedGate.AppHost.Client.x64.csproj", "{B9B7B458-D610-420E-89C5-96EBF49EFA01}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".SolutionItems", ".SolutionItems", "{9876CE58-F216-4DB8-9BD0-0079E5E5247C}"
+	ProjectSection(SolutionItems) = preProject
+		LICENSE.md = LICENSE.md
+		README.md = README.md
+		Install\RedGate.AppHost.wxs = Install\RedGate.AppHost.wxs
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
Makes the .wxs file comply with the rules as now implemented by the Wix Linter

Split up into two components