### PR TITLE
Don't include exe's as references, but still copy to output directory

### DIFF
--- a/NuSpec/Build/RedGate.AppHost.targets
+++ b/NuSpec/Build/RedGate.AppHost.targets
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup Condition="$(RedGateAppHostOutputPath) == ''">
+        <RedGateAppHostOutputPath>$(TargetDir)</RedGateAppHostOutputPath>
+    </PropertyGroup>
+    <Target Name="CopyRedGateAppHostFiles" AfterTargets="Build">
+        <ItemGroup>
+            <RedGateAppHostFiles Include="$(MSBuildThisFileDirectory)\..\tools\**\*.*" />
+        </ItemGroup>
+        <Copy SourceFiles="@(RedGateAppHostFiles)" DestinationFiles="@(RedGateAppHostFiles->'$(RedGateAppHostOutputPath)\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+    </Target>
+</Project>

--- a/NuSpec/Build/RedGate.AppHost.targets
+++ b/NuSpec/Build/RedGate.AppHost.targets
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup Condition="$(RedGateAppHostOutputPath) == ''">
-        <RedGateAppHostOutputPath>$(TargetDir)</RedGateAppHostOutputPath>
-    </PropertyGroup>
-    <Target Name="CopyRedGateAppHostFiles" AfterTargets="Build">
-        <ItemGroup>
-            <RedGateAppHostFiles Include="$(MSBuildThisFileDirectory)\..\tools\**\*.*" />
-        </ItemGroup>
-        <Copy SourceFiles="@(RedGateAppHostFiles)" DestinationFiles="@(RedGateAppHostFiles->'$(RedGateAppHostOutputPath)\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
-    </Target>
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\AppHostClientExe\**">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/NuSpec/RedGate.AppHost.nuspec
+++ b/NuSpec/RedGate.AppHost.nuspec
@@ -20,6 +20,11 @@
   </dependencies>
   </metadata>
   <files>
+    <file src="RedGate.AppHost.Client.exe" target="AppHostClientExe" />
+    <file src="RedGate.AppHost.Client.pdb" target="AppHostClientExe" />
+    <file src="RedGate.AppHost.Client.x64.exe" target="AppHostClientExe" />
+    <file src="RedGate.AppHost.Client.x64.pdb" target="AppHostClientExe" />
+    
     <file src="Build\RedGate.AppHost.targets" target="Build" />
     
     <file src="RedGate.AppHost.Example.Client.dll" target="lib" />
@@ -33,11 +38,6 @@
     <file src="RedGate.AppHost.Remoting.WPF.pdb" target="lib" />
     <file src="RedGate.AppHost.Server.dll" target="lib" />
     <file src="RedGate.AppHost.Server.pdb" target="lib" />
-    
-    <file src="RedGate.AppHost.Client.exe" target="tools" />
-    <file src="RedGate.AppHost.Client.pdb" target="tools" />
-    <file src="RedGate.AppHost.Client.x64.exe" target="tools" />
-    <file src="RedGate.AppHost.Client.x64.pdb" target="tools" />
     
     <file src="RedGate.AppHost.wxs" target="WiX2\RedGate.AppHost.wxs" />
   </files>

--- a/NuSpec/RedGate.AppHost.nuspec
+++ b/NuSpec/RedGate.AppHost.nuspec
@@ -12,8 +12,6 @@
     <summary>Provides a way to host a UI out of process and remote it in</summary>
     <references>
       <reference file="RedGate.AppHost.Server.dll" />
-      <reference file="RedGate.AppHost.Client.exe" />
-      <reference file="RedGate.AppHost.Client.x64.exe" />
       <reference file="RedGate.AppHost.Interfaces.dll" />
       <reference file="RedGate.AppHost.Remoting.WPF.dll" />
     </references>
@@ -22,13 +20,11 @@
   </dependencies>
   </metadata>
   <files>
+    <file src="Build\RedGate.AppHost.targets" target="Build" />
+    
     <file src="RedGate.AppHost.Example.Client.dll" target="lib" />
     <file src="RedGate.AppHost.Example.Server.exe" target="lib" />
     <file src="RedGate.AppHost.Example.Remote.Services.dll" target="lib" />
-    <file src="RedGate.AppHost.Client.exe" target="lib" />
-    <file src="RedGate.AppHost.Client.pdb" target="lib" />
-    <file src="RedGate.AppHost.Client.x64.exe" target="lib" />
-    <file src="RedGate.AppHost.Client.x64.pdb" target="lib" />
     <file src="RedGate.AppHost.Interfaces.dll" target="lib" />
     <file src="RedGate.AppHost.Interfaces.pdb" target="lib" />
     <file src="RedGate.AppHost.Remoting.dll" target="lib" />
@@ -37,6 +33,12 @@
     <file src="RedGate.AppHost.Remoting.WPF.pdb" target="lib" />
     <file src="RedGate.AppHost.Server.dll" target="lib" />
     <file src="RedGate.AppHost.Server.pdb" target="lib" />
+    
+    <file src="RedGate.AppHost.Client.exe" target="tools" />
+    <file src="RedGate.AppHost.Client.pdb" target="tools" />
+    <file src="RedGate.AppHost.Client.x64.exe" target="tools" />
+    <file src="RedGate.AppHost.Client.x64.pdb" target="tools" />
+    
     <file src="RedGate.AppHost.wxs" target="WiX2\RedGate.AppHost.wxs" />
   </files>
 </package>

--- a/RedGate.AppHost.sln
+++ b/RedGate.AppHost.sln
@@ -35,6 +35,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".SolutionItems", ".Solution
 		Install\RedGate.AppHost.wxs = Install\RedGate.AppHost.wxs
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{7E97DF57-D9F8-4D87-AFA2-349057114EFC}"
+	ProjectSection(SolutionItems) = preProject
+		NuSpec\Build\RedGate.AppHost.targets = NuSpec\Build\RedGate.AppHost.targets
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -85,5 +90,6 @@ Global
 		{01D94911-0A29-47FB-9691-10ABFD0B78AB} = {7B141F5F-D3EE-4D11-90A5-C65AD6F709B5}
 		{516C4CE3-F671-4E6A-A55D-952D08D3850E} = {7B141F5F-D3EE-4D11-90A5-C65AD6F709B5}
 		{EAFB4321-3E74-40D1-8369-D1667C374D9C} = {7B141F5F-D3EE-4D11-90A5-C65AD6F709B5}
+		{7E97DF57-D9F8-4D87-AFA2-349057114EFC} = {F17E9FBD-DD6E-4207-8C45-CFF4E643DDFD}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This PR adds a targets file that copies the exe files to the output of any projects its included in, and stops them being pulled in as dll references.

I created the new NuGet package and included it in a .net35 project. It Copied the exes to the ouput dir, but didn't reference them directly.